### PR TITLE
Badge native markdown markup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<a href="https://travis-ci.org/insideout10/helixware-plugin"><img align="right" src="https://travis-ci.org/insideout10/helixware-plugin.png?branch=master" /></a><br/>
-<a href="https://codeclimate.com/github/insideout10/helixware-plugin"><img align="right" src="https://codeclimate.com/github/insideout10/helixware-plugin.png" /></a>
+[![Build Status](https://secure.travis-ci.org/insideout10/helixware-plugin.svg?branch=master)](https://travis-ci.org/insideout10/helixware-plugin)
+[![Code Rewview](https://codeclimate.com/github/insideout10/helixware-plugin.png)](https://codeclimate.com/github/insideout10/helixware-plugin)
 
 
 HelixWare plugin


### PR DESCRIPTION
Then it will look much nicer at the mico mirror at https://bitbucket.org/mico-project/helixware-plugin
